### PR TITLE
Fix - mui-datatables data display

### DIFF
--- a/web/src/components/tables/mui-datatables/Table.stories.tsx
+++ b/web/src/components/tables/mui-datatables/Table.stories.tsx
@@ -1,40 +1,58 @@
-import MUIDataTable from "mui-datatables";
-import {storiesOf} from "@storybook/react";
 import * as React from "react";
+import MUIDataTable, { FilterType, MUIDataTableOptions } from "mui-datatables";
+import { storiesOf } from "@storybook/react";
 
 const columns = [
   {
-    name: "claim",
-    label: "Claim",
+    name: "name",
+    label: "Name",
     options: {
       filter: true,
-      sort: true,
+      sort: true
     }
   },
   {
-    name: "time",
-    label: "Time",
+    name: "company",
+    label: "Company",
     options: {
       filter: true,
-      sort: false,
+      sort: false
     }
   },
+  {
+    name: "city",
+    label: "City",
+    options: {
+      filter: true,
+      sort: false
+    }
+  },
+  {
+    name: "state",
+    label: "State",
+    options: {
+      filter: true,
+      sort: false
+    }
+  }
 ];
 
 const data = [
   { name: "Joe James", company: "Test Corp", city: "Yonkers", state: "NY" },
   { name: "John Walsh", company: "Test Corp", city: "Hartford", state: "CT" },
   { name: "Bob Herm", company: "Test Corp", city: "Tampa", state: "FL" },
-  { name: "James Houston", company: "Test Corp", city: "Dallas", state: "TX" },
+  { name: "James Houston", company: "Test Corp", city: "Dallas", state: "TX" }
 ];
 
-storiesOf("Components|Tables/mui-datatables", module)
-  .add("default", () =>
-    <MUIDataTable
-      title={"Employee List"}
-      data={data}
-      columns={columns}
-      options={{pagination:false}}
-    />
-  );
+const options: MUIDataTableOptions = {
+  filterType: "checkbox"
+};
 
+storiesOf("Components|Tables/mui-datatables", module).add("default", () => (
+  <MUIDataTable
+    title={"Employee List"}
+    data={data}
+    columns={columns}
+    options={options}
+  />
+));


### PR DESCRIPTION
In this PR we fix the storybook story of rendering an example of table using `mui-datatables` library, now you can see it in action.

**Before**
<img width="1270" alt="Screenshot 2019-07-16 16 27 12" src="https://user-images.githubusercontent.com/52924533/61302746-983d9480-a7e6-11e9-94a3-4290b3feaf74.png">


**After**

<img width="1272" alt="PR" src="https://user-images.githubusercontent.com/52924533/61302589-57de1680-a7e6-11e9-9ed3-3ab6a73f76a2.png">
